### PR TITLE
Add BugCatcher static analysis to testing and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2
+
+jobs:
+
+  build:
+    filters: &filters # using regex filters requires the entire branch to match
+      branches:
+        only:  # only branches matching the below regex filters will run
+          - bugcatcher
+    docker:
+      - image: circleci/python:3.7.5
+    steps: &steps
+      - checkout
+      - run: sudo pip install .
+      - run: sudo pip install coverage flake8 pytest
+      - run: python --version ; pip --version ; pwd ; ls
+      # stop the build if there are Python syntax errors or undefined names
+      - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - run: pytest -s
+  
+  Python_3.7:
+    docker:
+      - image: circleci/python:3.7
+    filters: *filters
+    steps: *steps
+  
+  Python_3.6:
+    docker:
+      - image: circleci/python:3.6
+    filters: *filters
+    steps: *steps
+  
+  Python_3.5:
+    docker:
+      - image: circleci/python:3.5
+    filters: *filters
+    steps: *steps
+        
+workflows:
+  version: 2
+
+  workflow:
+    jobs:
+      - build
+      - Python_3.7
+      - Python_3.6
+      - Python_3.5

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['peppercorn'],  # Optional
+    install_requires=['bugcatcher-ci', 'peppercorn'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -2,6 +2,20 @@
 # testing in general, but rather to support the `find_packages` example in
 # setup.py that excludes installing the "tests" package
 
+import os
+
+bugcatcher_ci = __import__('bugcatcher-ci')
+ftl_sid = os.environ.get('FTL_SID') # Keep it secure!
+ftl_project = os.environ.get('FTL_PROJECT') or 'BUGCATCHER CI'
+ftl = bugcatcher_ci.CI(ftl_sid, ftl_project)
+
+def test_with_bugcatcher():
+    print("\nTesting codebase with BugCatcher API...")
+    uploaded = ftl.push(ftl_project, ".")
+    assert uploaded
+    tested = ftl.test(ftl_project, 'medium')
+    assert tested
+
 
 def test_success():
     assert True


### PR DESCRIPTION
To add static analysis to your continuous integration and continuous deployment plans, simply use the Python package named `bugcatcher-ci` (https://pypi.org/project/bugcatcher-ci/).

Please view the changed files in this PR. Setting up your testing is as easy as following this example and making sure you have an environment variable saved on CircleCI/TravisCI for `FTL_SID`. Your `FTL_SID` can be found on the dashboard of your BugCatcher account at https://bugcatcher.fasterthanlight.dev